### PR TITLE
`bundle lock --add-platform x86_64-linux`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,8 @@ GEM
     nio4r (2.5.7)
     nokogiri (1.11.3-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.11.3-x86_64-linux)
+      racc (~> 1.4)
     puma (4.3.7)
       nio4r (~> 2.0)
     racc (1.5.2)
@@ -154,6 +156,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-linux
 
 DEPENDENCIES
   active_hash


### PR DESCRIPTION
https://dashboard.heroku.com/apps/sample-accounts-api/activity/builds/de43e8b1-cefe-4842-8ae2-52f24872de37
```
-----> Building on the Heroku-20 stack
-----> Using buildpack: heroku/ruby
-----> Ruby app detected
-----> Installing bundler 2.2.16
-----> Removing BUNDLED WITH version in the Gemfile.lock
-----> Compiling Ruby/Rails
###### WARNING:
       Your app was upgraded to bundler 2.2.16.
       Previously you had a successful deploy with bundler 1.17.3.
       
       If you see problems related to the bundler version please refer to:
       https://devcenter.heroku.com/articles/bundler-version#known-upgrade-issues
       
-----> Using Ruby version: ruby-2.7.3
       Purging Cache. Changing stack from heroku-16 to heroku-20
-----> Installing dependencies using bundler 2.2.16
       Running: BUNDLE_WITHOUT='development:test' BUNDLE_PATH=vendor/bundle BUNDLE_BIN=vendor/bundle/bin BUNDLE_DEPLOYMENT=1 bundle install -j4
       Your bundle only supports platforms ["x86_64-darwin-19"] but your local platform
       is x86_64-linux. Add the current platform to the lockfile with `bundle lock
       --add-platform x86_64-linux` and try again.
       Bundler Output: Your bundle only supports platforms ["x86_64-darwin-19"] but your local platform
       is x86_64-linux. Add the current platform to the lockfile with `bundle lock
       --add-platform x86_64-linux` and try again.
 !
 !     Failed to install gems via Bundler.
 !
 !     Push rejected, failed to compile Ruby app.
 !     Push failed
```